### PR TITLE
Use Golang 1.18.

### DIFF
--- a/code_go.ML
+++ b/code_go.ML
@@ -712,7 +712,7 @@ fun serialize_go gen_stringer go_module undefineds infinite_types ctxt { module_
       then Code_Target.Singleton ("go", snd (hd p))
       else Code_Target.Hierarchy ((["go.mod"], Pretty.chunks2 [
         concat [str "module",(str o print_go_string) go_module],
-        str "go 1.19"
+        str "go 1.18"
       ]) :: p),
     try (deresolver [])
   ) end;

--- a/go_test/go/go.mod
+++ b/go_test/go/go.mod
@@ -1,3 +1,3 @@
 module "isabelle/exported"
 
-go 1.19
+go 1.18


### PR DESCRIPTION
I think that's what the paper says.
Also, I think https://hub.docker.com/r/makarius/isabelle is based in ubuntu22.04, which ships go 1.18.

go test -v ./Interface
did succeed on my system with Golang 1.18.